### PR TITLE
Fix pkg already installed on 2nd puppet run + fix environment.sh

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class wsgi::params {
   case $::osfamily {
     'RedHat': {
 
-      $python_pkg     = 'lr-python3'
+      $python_pkg     = 'lr-python3-3.4.3-1.x86_64'
       $python_pkg_url = 'http://rpm.landregistryconcept.co.uk/landregistry/x86_64/lr-python3-3.4.3-1.x86_64.rpm'
 
       $systemd = '/usr/lib/systemd/system'

--- a/templates/environment.erb
+++ b/templates/environment.erb
@@ -1,12 +1,12 @@
 # Environment variables for <%= @name %>
 
 # If VERSION or COMMIT exist expose them as variables
-[ -f '<%= @directory %>/VERSION' ] && VERSION=$(cat <%= @directory %>/VERSION)
-[ -f '<%= @directory %>/COMMIT' ]  && COMMIT=$(cat <%= @directory %>/COMMIT)
+[ -f '<%= @directory %>/VERSION' ] && export VERSION=$(cat <%= @directory %>/VERSION)
+[ -f '<%= @directory %>/COMMIT' ]  && export COMMIT=$(cat <%= @directory %>/COMMIT)
 
 <%- if @vars -%>
 # Application-specific variables
   <%- @vars.sort.map do |key,value| -%>
-<%= key %>='<%= value %>'
+export <%= key %>='<%= value %>'
   <%- end -%>
 <%- end -%>


### PR DESCRIPTION
This change addresses two bugs:

1) After an initial successful run subsequent puppet runs were failing with an error stating that the lr-python package was already installed - this was caused by an issue with the puppet rpm package provider which exhibits odd behaviour (such as this) when the resource name does not exactly match the package name (minus the file extension). Fixed by amending the resource name to match the package name.

2) The environment.sh script did not include export commands for the environment variables. - Fixed by amending template to include the required export commands.       