### PR TITLE
Bugfix venv

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -150,11 +150,11 @@ define wsgi::application (
     }
 
     exec { "${name} dependencies":
-      command     => "${venv_dir}/bin/pip install -r ${code_dir}/requirements.txt",
-      user        => $owner,
-      group       => $group,
-      require     => [Exec["${name} virtualenv"], File["${name} requirements.txt"]],
-      refreshonly => true
+      command => "${venv_dir}/bin/pip install -r ${code_dir}/requirements.txt",
+      user    => $owner,
+      group   => $group,
+      require => [Exec["${name} virtualenv"], File["${name} requirements.txt"]],
+      #refreshonly => true
     }
 
     exec { "${name} gunicorn":

--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -15,7 +15,7 @@ define wsgi::application (
   $vars       = undef,
   $source     = undef,
   $revision   = undef,
-
+  $app_type   = 'wsgi'
 ) {
 
   include stdlib
@@ -44,7 +44,11 @@ define wsgi::application (
 
     # Input validation
     ############################################################################
-    if $bind == undef {
+    if $app_type in ['wsgi', 'python'] == false {
+      fail( 'Not a valid app type')
+    }
+
+    if $app_type == 'wsgi' and $bind == undef {
       fail( 'Bind value must be set to an integer representing a network port')
     }
     if $source == undef {

--- a/templates/environment.erb
+++ b/templates/environment.erb
@@ -7,6 +7,6 @@
 <%- if @vars -%>
 # Application-specific variables
   <%- @vars.sort.map do |key,value| -%>
-<%= key %>='<%= value %>'
+export <%= key %>='<%= value %>'
   <%- end -%>
 <%- end -%>

--- a/templates/service.erb
+++ b/templates/service.erb
@@ -1,7 +1,7 @@
 # SystemD service script for <%= @name %>
 
 [Unit]
-Description=Land Registry's <%= @name %> WSGI application
+Description=Land Registry's <%= @name %> <%= @app_type %> application
 After=network.target
 
 [Service]

--- a/templates/startup.erb
+++ b/templates/startup.erb
@@ -40,6 +40,6 @@ $GUNICORN --bind           0.0.0.0:${PORT} \
           <%= @wsgi_entry %> # Entry point
 
 <%- elsif @app_type == 'python' -%>
-python3 <%= @code_dir %>/run.py
+<%= @venv_dir %>/bin/python <%= @code_dir %>/run.py
 
 <% end %>

--- a/templates/startup.erb
+++ b/templates/startup.erb
@@ -26,6 +26,7 @@ if [ -f '<%= @code_dir %>/manage.py' ]; then
 fi
 <%- end -%>
 
+<%- if @app_type == 'wsgi' -%>
 # Run time
 echo "Starting web service on ${PORT}..."
 GUNICORN='<%= @venv_dir %>/bin/gunicorn'
@@ -37,3 +38,8 @@ $GUNICORN --bind           0.0.0.0:${PORT} \
           --error-logfile  '<%= @error_log %>' \
           --log-level      <%= @log_level %> \
           <%= @wsgi_entry %> # Entry point
+
+<%- elsif @app_type == 'python' -%>
+python3 <%= @code_dir %>/run.py
+
+<% end %>

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -27,7 +27,7 @@ wsgi::application { 'test-api':
   ensure => absent
 } ->
 wsgi::application { 'digital-register-feeder':
-  source     => 'https://github.com/LandRegistry/digital-register-feeder.git',
+  source     => 'git@github.com:LandRegistry/digital-register-feeder.git',
   app_type   => 'python',
   vars       => {
     db_url => 'http://ghj',

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -25,4 +25,27 @@ wsgi::application { 'cases-api':
 } ->
 wsgi::application { 'test-api':
   ensure => absent
+} ->
+wsgi::application { 'digital-register-feeder':
+  source     => 'https://github.com/LandRegistry/digital-register-feeder.git',
+  app_type   => 'python',
+  vars       => {
+    db_url => 'http://ghj',
+    'SETTINGS' => 'dev',
+    'REGISTER_FILES_PATH' => 'data',
+    'POSTGRES_USER' => 'postgres',
+    'POSTGRES_PASSWORD' => 'password',
+    'POSTGRES_HOST' => '127.0.0.1',
+    'POSTGRES_PORT' => '5432',
+    'POSTGRES_DB' => 'register_data',
+    'DIGITAL_REGISTER_URL' => 'http://landregistry.local:8003',
+    'ELASTICSEARCH_HOST' => 'localhost',
+    'ELASTICSEARCH_PORT' => '9200',
+    'INCOMING_QUEUE' => 'publish_queue',
+    'INCOMING_QUEUE_HOSTNAME' => 'localhost',
+    'LOGGING_CONFIG_FILE_PATH' => 'logging_config.json',
+    'FAULT_LOG_FILE_PATH' => '/var/log/digital-register-feeder-fault.log',
+    'SHOW_PRIVATE_PROPRIETORS' => 'true',
+    'LOG_SCHEMA_VALIDATION_ERRORS' => 'false',
+  }
 }

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -31,7 +31,7 @@ wsgi::application { 'digital-register-feeder':
   app_type   => 'python',
   vars       => {
     db_url => 'http://ghj',
-    'SETTINGS' => 'dev',
+    'SETTINGS' => 'test',
     'REGISTER_FILES_PATH' => 'data',
     'POSTGRES_USER' => 'postgres',
     'POSTGRES_PASSWORD' => 'password',


### PR DESCRIPTION
At present pip dependencies in a virtual env are only installed when the virtual env is initially created. Unfortunately this means that if the initial puppet run fails then the pip dependencies may never be installed.

This change addresses this issue by ensuring that an attempt to install the pip dependencies is made on every puppet run.

This is a less than ideal solution as puppet will now report changes on every run even if there have been none.  Long term it will be necessary to find a truly idempotent means of installing pip dependencies. 