### PR TITLE
Add abillity to define additional arguments to app start up scripts

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -21,7 +21,8 @@ define wsgi::application (
   $vs_server    = undef,
   $environment  = undef,
   $vs_app_host  = undef,
-  $vs_app_token = undef
+  $vs_app_token = undef,
+  $extra_args   = undef
 ) {
 
   include stdlib

--- a/templates/startup_jar.erb
+++ b/templates/startup_jar.erb
@@ -12,5 +12,5 @@ source <%= @cfg_file  %>
 export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk/
 cd <%= @code_dir %>
 
-nohup java -jar <%= @jar_name  %> 2> <%= @error_log %> 1> <%= @access_log %> &
+nohup java -jar <%= @jar_name  %> <%= @extra_args %> 2> <%= @error_log %> 1> <%= @access_log %> &
 echo $! > ../<%= @service %>.pid

--- a/templates/startup_python.erb
+++ b/templates/startup_python.erb
@@ -12,4 +12,4 @@ source <%= @cfg_file  %>
 PYTHONPATH='<%= @code_dir %>'
 cd <%= @code_dir %>
 
-<%= @venv_dir %>/bin/python <%= @code_dir %>/run.py
+<%= @venv_dir %>/bin/python <%= @code_dir %>/run.py <%= @extra_args %>

--- a/templates/startup_wsgi.erb
+++ b/templates/startup_wsgi.erb
@@ -38,4 +38,5 @@ $GUNICORN --bind           0.0.0.0:${PORT} \
           --log-level      <%= @log_level %> \
           --workers        <%= @workers %> \
           --threads        <%= @threads %> \
+          <%= @extra_args %> \
           "<%= @wsgi_entry %>" # Entry point


### PR DESCRIPTION
Change is required to enable the GDS created verify matching adaptor to be deployed. It requires extra arguments to be passed to the jar at launch.