### PR TITLE
Added default user for applications

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,8 +5,6 @@
 #
 class wsgi::params {
 
-  $user       = 'root'
-  $group      = 'root'
   $wsgi_entry = 'application.routes:app'
   $app_dir    = '/opt/landregistry/applications'
 

--- a/manifests/types/wsgi.pp
+++ b/manifests/types/wsgi.pp
@@ -1,6 +1,4 @@
 
-
-
 define wsgi::types::wsgi(
   $code_dir = undef,
   $venv_dir = undef,

--- a/templates/service.erb
+++ b/templates/service.erb
@@ -7,8 +7,8 @@ After=network.target
 [Service]
 Type=simple
 PIDFile=<%= @pid_file %>
-User=<%= @owner %>
-Group=<%= @group %>
+User=<%= @app_user %>
+Group=<%= @app_group %>
 WorkingDirectory=<%= @code_dir %>
 ExecStart=<%= @start_sh %>
 ExecReload=/bin/kill -s HUP $MAINPID


### PR DESCRIPTION
The previous default behaviour of running applications as root unless `owner` was specified now seems a little silly. It definitely makes more sense to create an manage a service account for each application unless the `owner` field is specified.