### PR TITLE
Major logging enhancements

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -30,21 +30,22 @@ define wsgi::application (
 
   # Static variables
   ##############################################################################
-  $venv_dir       = "${directory}/virtualenv"
-  $code_dir       = "${directory}/source"
-  $logs_dir       = "${directory}/logs"
-  $pid_file       = "${directory}/${service}.pid"
-  $cfg_file       = "${directory}/settings.conf"
-  $dep_file       = "${directory}/deploy.conf"
-  $start_sh       = "${directory}/startup.sh"
-  $sysd_link      = "${directory}/${service}.service"
-  $sysd_file      = "${wsgi::params::systemd}/${service}.service"
-  $logrotate_file = "${wsgi::params::logrotate}/${service}.conf"
-  $commit_file    = "${directory}/COMMIT"
-  $version_file   = "${directory}/VERSION"
-  $access_log     = "${logs_dir}/access.log"
-  $error_log      = "${logs_dir}/error.log"
-  $log_level      = 'info'
+  $venv_dir        = "${directory}/virtualenv"
+  $code_dir        = "${directory}/source"
+  $logs_dir        = "${directory}/logs"
+  $pid_file        = "${directory}/${service}.pid"
+  $cfg_file        = "${directory}/settings.conf"
+  $dep_file        = "${directory}/deploy.conf"
+  $start_sh        = "${directory}/startup.sh"
+  $sysd_link       = "${directory}/${service}.service"
+  $sysd_file       = "${wsgi::params::systemd}/${service}.service"
+  $logrotate_file  = "${wsgi::params::logrotate}/${service}.conf"
+  $commit_file     = "${directory}/COMMIT"
+  $version_file    = "${directory}/VERSION"
+  $access_log      = "${logs_dir}/access.log"
+  $error_log       = "${logs_dir}/error.log"
+  $application_log = "${logs_dir}/application.log"
+  $log_level       = 'info'
 
   # If a user/group is not specified we should assume the user should have it's
   # own account for which we'll use the same name as the service itself.

--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -294,6 +294,7 @@ define wsgi::application (
 
     file { $sysd_file :      ensure => absent }
     file { $logrotate_file : ensure => absent }
+
   # Fail if we receive an unusual ensure value
   ##############################################################################
   } else {

--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -198,7 +198,7 @@ define wsgi::application (
         $filebeat_conf = "/etc/filebeat/filebeat.d/${service}.yml"
         ensure_resource('file', $filebeat_dirs, { ensure => directory })
 
-        file { $filebeat_conf : 
+        file { $filebeat_conf :
           ensure  => present,
           owner   => $app_user,
           group   => $app_group,

--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -30,20 +30,21 @@ define wsgi::application (
 
   # Static variables
   ##############################################################################
-  $venv_dir     = "${directory}/virtualenv"
-  $code_dir     = "${directory}/source"
-  $logs_dir     = "${directory}/logs"
-  $pid_file     = "${directory}/${service}.pid"
-  $cfg_file     = "${directory}/settings.conf"
-  $dep_file     = "${directory}/deploy.conf"
-  $start_sh     = "${directory}/startup.sh"
-  $sysd_link    = "${directory}/${service}.service"
-  $sysd_file    = "${wsgi::params::systemd}/${service}.service"
-  $commit_file  = "${directory}/COMMIT"
-  $version_file = "${directory}/VERSION"
-  $access_log   = "${logs_dir}/access.log"
-  $error_log    = "${logs_dir}/error.log"
-  $log_level    = 'info'
+  $venv_dir       = "${directory}/virtualenv"
+  $code_dir       = "${directory}/source"
+  $logs_dir       = "${directory}/logs"
+  $pid_file       = "${directory}/${service}.pid"
+  $cfg_file       = "${directory}/settings.conf"
+  $dep_file       = "${directory}/deploy.conf"
+  $start_sh       = "${directory}/startup.sh"
+  $sysd_link      = "${directory}/${service}.service"
+  $sysd_file      = "${wsgi::params::systemd}/${service}.service"
+  $logrotate_file = "${wsgi::params::logrotate}/${service}.conf"
+  $commit_file    = "${directory}/COMMIT"
+  $version_file   = "${directory}/VERSION"
+  $access_log     = "${logs_dir}/access.log"
+  $error_log      = "${logs_dir}/error.log"
+  $log_level      = 'info'
 
   # If a user/group is not specified we should assume the user should have it's
   # own account for which we'll use the same name as the service itself.
@@ -262,6 +263,14 @@ define wsgi::application (
       require    => File[$sysd_file]
     }
 
+    file { $logrotate_file :
+      ensure  => present,
+      owner   => $app_user,
+      group   => $app_group,
+      mode    => '0644',
+      content => template('wsgi/logrotate.erb')
+    }
+
   # Remove application & configuration
   ##############################################################################
   } elsif $ensure == 'absent' {
@@ -283,9 +292,8 @@ define wsgi::application (
       enable => false
     }
 
-    file { $sysd_file:
-      ensure => absent
-    }
+    file { $sysd_file :      ensure => absent }
+    file { $logrotate_file : ensure => absent }
   # Fail if we receive an unusual ensure value
   ##############################################################################
   } else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,8 @@ class wsgi::params {
       $python_pkg     = 'lr-python3-3.4.3-1.x86_64'
       $python_pkg_url = 'http://rpm.landregistryconcept.co.uk/landregistry/x86_64/lr-python3-3.4.3-1.x86_64.rpm'
 
-      $systemd = '/usr/lib/systemd/system'
+      $systemd   = '/usr/lib/systemd/system'
+      $logrotate = '/etc/logrotate.d'
 
     }
 

--- a/manifests/types/wsgi.pp
+++ b/manifests/types/wsgi.pp
@@ -11,7 +11,6 @@ define wsgi::types::wsgi(
   $bind     = undef,
   ){
 
-
     if $bind == undef {
       fail( 'Bind value must be set to an integer representing a network port')
     }

--- a/templates/filebeat.erb
+++ b/templates/filebeat.erb
@@ -1,0 +1,26 @@
+# Filebeat configuration for <%= @name %> application.
+
+filebeat:
+
+  prospectors:
+
+    # Application log configuration.
+    -
+      paths:
+        - <%= @application_log %>
+        - <%= @error_log %>
+      document_type: lr-application
+      fields:
+        application: '<%= @name %>'
+        environment: '<%= @environment %>'
+        version:     '<%= @revision %>'
+
+    # HTTP access log configuration.
+    -
+      paths:
+        - <%= @access_log %>
+      document_type: access
+      fields:
+        application: '<%= @name %>'
+        environment: '<%= @environment %>'
+        version:     '<%= @revision %>'

--- a/templates/logrotate.erb
+++ b/templates/logrotate.erb
@@ -1,0 +1,12 @@
+## MANAGED BY PUPPET
+
+# Backup <%= @service %> log files
+<%= @logging_path %>/*.log {
+  missingok
+  notifempty
+  dateext
+  dateformat %Y-%m-%d
+  rotate 4
+  weekly
+  compress
+}

--- a/templates/startup_jar.erb
+++ b/templates/startup_jar.erb
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Startup script for Land Registry's <%= @name %> WSGI application
+# Startup script for Land Registry's <%= @name %> Java application
 
 # Port the application should listen on
 export PORT=<%= @bind %>
@@ -12,5 +12,7 @@ source <%= @cfg_file  %>
 export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk/
 cd <%= @code_dir %>
 
+# Run time
+echo "Starting web service on ${PORT}..."
 nohup java -jar <%= @jar_name  %> <%= @extra_args %> 2> <%= @error_log %> 1> <%= @access_log %> &
 echo $! > ../<%= @service %>.pid

--- a/templates/startup_jar.erb
+++ b/templates/startup_jar.erb
@@ -8,11 +8,15 @@ export PORT=<%= @bind %>
 echo 'Loading environment variables...'
 source <%= @cfg_file  %>
 
-# Ensure python can find modules correctly
+# Ensure Java is configured correctly
 export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk/
 cd <%= @code_dir %>
 
+# Logging configuration
+ERROR_LOG='<%= @error_log %>'
+APPLICATION_LOG='<%= @application_log %>'
+
 # Run time
 echo "Starting web service on ${PORT}..."
-nohup java -jar <%= @jar_name  %> <%= @extra_args %> 2> <%= @error_log %> 1> <%= @access_log %> &
+nohup java -jar <%= @jar_name  %> <%= @extra_args %> > >(tee -a ${APPLICATION_LOG}) 2> >(tee -a ${ERROR_LOG} >&2) &
 echo $! > ../<%= @service %>.pid

--- a/templates/startup_python.erb
+++ b/templates/startup_python.erb
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Startup script for Land Registry's <%= @name %> WSGI application
+# Startup script for Land Registry's <%= @name %> Python application
 
 # Port the application should listen on
-PORT=<%= @bind %>
+export PORT=<%= @bind %>
 
 # Load environment variables
 echo 'Loading environment variables...'
@@ -12,4 +12,6 @@ source <%= @cfg_file  %>
 PYTHONPATH='<%= @code_dir %>'
 cd <%= @code_dir %>
 
+# Run time
+echo "Starting python service..."
 <%= @venv_dir %>/bin/python <%= @code_dir %>/run.py <%= @extra_args %>

--- a/templates/startup_python.erb
+++ b/templates/startup_python.erb
@@ -12,6 +12,9 @@ source <%= @cfg_file  %>
 PYTHONPATH='<%= @code_dir %>'
 cd <%= @code_dir %>
 
+# Logging configuration
+APPLICATION_LOG='<%= @application_log %>'
+
 # Run time
 echo "Starting python service..."
-<%= @venv_dir %>/bin/python <%= @code_dir %>/run.py <%= @extra_args %>
+<%= @venv_dir %>/bin/python <%= @code_dir %>/run.py <%= @extra_args %> > >(tee -a ${APPLICATION_LOG}) 2> >(tee -a ${APPLICATION_LOG} >&2)

--- a/templates/startup_wsgi.erb
+++ b/templates/startup_wsgi.erb
@@ -30,6 +30,11 @@ fi
 echo 'Re-Loading standard environment variables...'
 source <%= @cfg_file  %>
 
+# Logging configuration
+ACCESS_LOG='<%= @access_log %>'
+ERROR_LOG='<%= @error_log %>'
+APPLICATION_LOG='<%= @application_log %>'
+
 # Run time
 echo "Starting web service on ${PORT}..."
 GUNICORN='<%= @venv_dir %>/bin/gunicorn'
@@ -37,10 +42,10 @@ $GUNICORN --bind           0.0.0.0:${PORT} \
           --name           <%= @service  %> \
           --pid            '<%= @pid_file %>' \
           --chdir          '<%= @code_dir %>/' \
-          --access-logfile '<%= @access_log %>' \
-          --error-logfile  '<%= @error_log %>' \
+          --error-logfile  ${ERROR_LOG} \
+          --access-logfile ${ACCESS_LOG} \
           --log-level      <%= @log_level %> \
           --workers        <%= @workers %> \
           --threads        <%= @threads %> \
           <%= @extra_args %> \
-          "<%= @wsgi_entry %>" # Entry point
+          "<%= @wsgi_entry %>" > >(tee -a ${APPLICATION_LOG}) 2> >(tee -a ${APPLICATION_LOG} >&2)

--- a/templates/startup_wsgi.erb
+++ b/templates/startup_wsgi.erb
@@ -2,7 +2,7 @@
 # Startup script for Land Registry's <%= @name %> WSGI application
 
 # Port the application should listen on
-PORT=<%= @bind %>
+export PORT=<%= @bind %>
 
 # Load environment variables and immediatly override with any deployment varables
 echo 'Loading environment variables...'


### PR DESCRIPTION
I've added a few new features around improving the logging configuration for applications.

Firstly, in commit 17c0f16 I've added logrotate configurations in for all the applications. I haven't provided any configuration options for this so all applications will have their logs rotated weekly for four weeks and logs older than four weeks will be removed. This should reduce the risk of filesystem growth from logs.

Secondly, in commit e9435a3 I have added an additional log file, `application.log` to all the projects, designed to provide a standard output stream for log messages which aren't necessarily errors.

Lastly, in commit 841a1d9 I have added support for centralising log outputs using filebeat. Currently, until we have a better understanding of the logging standards for Java apps, it only supports the `wsgi` application type. To enable logging you can simply add the `logging => true` line to the application resource when defining it.

I've been able to attach some useful metadata to the log entries when they are shipped from filebeat. Here is an example:
```json
{
  "@timestamp": "2016-09-06T16:45:21.869Z",
  "beat": {
    "hostname": "landregistry.box",
    "name": "landregistry.box"
  },
  "count": 1,
  "fields": {
    "application": "ha-demo",
    "environment": "development",
    "version": "master"
  },
  "input_type": "log",
  "message": "127.0.0.1 - - [06/Sep/2016:17:45:15 +0100] \"GET /backend HTTP/1.1\" 200 31 \"-\" \"curl/7.29.0\"",
  "offset": 0,
  "source": "/opt/landregistry/applications/ha-demo/logs/access.log",
  "type": "access"
}
{
  "@timestamp": "2016-09-06T16:45:21.869Z",
  "beat": {
    "hostname": "landregistry.box",
    "name": "landregistry.box"
  },
  "count": 1,
  "fields": {
    "application": "ha-demo",
    "environment": "development",
    "version": "master"
  },
  "input_type": "log",
  "message": "INFO:root:Backend triggered on landregistry.box",
  "offset": 0,
  "source": "/opt/landregistry/applications/ha-demo/logs/application.log",
  "type": "lr-application"
}
```
