### PR TITLE
Parameterise python file name for python type

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -24,6 +24,7 @@ define wsgi::application (
   $environment  = undef,
   $vs_app_host  = undef,
   $vs_app_token = undef,
+  $python_exe   = 'run.py',
   $extra_args   = undef
 ) {
 

--- a/templates/startup_python.erb
+++ b/templates/startup_python.erb
@@ -17,4 +17,4 @@ APPLICATION_LOG='<%= @application_log %>'
 
 # Run time
 echo "Starting python service..."
-<%= @venv_dir %>/bin/python <%= @code_dir %>/run.py <%= @extra_args %> > >(tee -a ${APPLICATION_LOG}) 2> >(tee -a ${APPLICATION_LOG} >&2)
+<%= @venv_dir %>/bin/python <%= @code_dir %>/<%= @python_exe %> <%= @extra_args %> > >(tee -a ${APPLICATION_LOG}) 2> >(tee -a ${APPLICATION_LOG} >&2)


### PR DESCRIPTION
It appears that we are unable to agree a standard name for the python file to be run for the python file type. This change addresses this issue by parametrising it.  