### PR TITLE
Added support for custom commands in Python type

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -25,6 +25,7 @@ define wsgi::application (
   $vs_app_host  = undef,
   $vs_app_token = undef,
   $python_exe   = 'run.py',
+  $command      = undef,
   $extra_args   = undef
 ) {
 
@@ -243,6 +244,7 @@ define wsgi::application (
         dep_file => $dep_file,
         start_sh => $start_sh,
         bind     => $bind,
+        command  => $command
       }
 
     } elsif ($app_type == 'batch') {

--- a/templates/startup_python.erb
+++ b/templates/startup_python.erb
@@ -9,7 +9,8 @@ echo 'Loading environment variables...'
 source <%= @cfg_file  %>
 
 # Ensure python can find modules correctly
-PYTHONPATH='<%= @code_dir %>'
+export PYTHONPATH='<%= @code_dir %>'
+export PATH="<%= @venv_dir %>/bin:${PATH}"
 cd <%= @code_dir %>
 
 # Logging configuration
@@ -17,4 +18,8 @@ APPLICATION_LOG='<%= @application_log %>'
 
 # Run time
 echo "Starting python service..."
+<% if @command %>
+<%= @command %> > >(tee -a ${APPLICATION_LOG}) 2> >(tee -a ${APPLICATION_LOG} >&2)
+<% else %>
 <%= @venv_dir %>/bin/python <%= @code_dir %>/<%= @python_exe %> <%= @extra_args %> > >(tee -a ${APPLICATION_LOG}) 2> >(tee -a ${APPLICATION_LOG} >&2)
+<% end %>


### PR DESCRIPTION
The `python` type application type is fairly inflexible at the moment, allowing the execution of Python scripts through the interpreter but does not provide the ability to run separate executables other than the `python` interpreter. This prevents the direct running of Gunicorn/Celery etc through this module.

I have added functionality which will support the execution of arbitary commands in a Python environment with use of the following:
```puppet
wsgi::application { 'test-python-app' :
  app_type    => 'python',
  command => 'command here'
}
```