### PR TITLE
Switch from lr-python3 to IUS Python 3

### DIFF
--- a/manifests/dependencies/java.pp
+++ b/manifests/dependencies/java.pp
@@ -6,10 +6,12 @@ class wsgi::dependencies::java () {
 
   include stdlib
 
-  pkgs = ['java-1.8.0-openjdk', 'java-1.8.0-openjdk-devel']
+  $version = '1.8'
 
-  # In order to avoid conflicts with other modules we simple want to ensure
+  $packages = ["java-${version}.0-openjdk", "java-${version}.0-openjdk-devel"]
+
+  # In order to avoid conflicts with other modules we simply want to ensure
   # that Java is installed. We do not need explicit 'ownership' of this resource
-  ensure_packages(${pkgs}, {'ensure' => 'present'})
+  ensure_packages($packages, {'ensure' => 'present'})
 
 }

--- a/manifests/dependencies/java.pp
+++ b/manifests/dependencies/java.pp
@@ -1,0 +1,15 @@
+# == Class: wsgi::dependencies::java
+#
+# Ensures Java is installed
+#
+class wsgi::dependencies::java () {
+
+  include stdlib
+
+  pkgs = ['java-1.8.0-openjdk', 'java-1.8.0-openjdk-devel']
+
+  # In order to avoid conflicts with other modules we simple want to ensure
+  # that Java is installed. We do not need explicit 'ownership' of this resource
+  ensure_packages(${pkgs}, {'ensure' => 'present'})
+
+}

--- a/manifests/dependencies/python.pp
+++ b/manifests/dependencies/python.pp
@@ -1,0 +1,32 @@
+# == Class: wsgi::dependencies::python
+#
+# Ensures Python is installed
+#
+class wsgi::dependencies::python () {
+
+  include stdlib
+
+  $version = '3.4'
+  $ver = regsubst($version, '\.', '')
+
+  # The IUS repository will provide upstream Python versions for our use.
+  # See https://ius.io/ for more information.
+  $ius_url  = 'https://centos7.iuscommunity.org/ius-release.rpm'
+  $ius_name = 'ius-release'
+
+  package { $ius_name :
+    ensure   => present,
+    provider => rpm,
+    source   => $ius_url
+  }
+
+  $packages = ["python${ver}u", "python${ver}u-pip", "python${ver}u-setuptools"]
+
+  # In order to avoid conflicts with other modules we simply want to ensure
+  # that Python is installed. We do not need explicit 'ownership' of this resource
+  ensure_packages($packages, { ensure => 'present', require => Package[$ius_name]})
+
+  # As lr-python3 could exist on systems as we used it previously, we'll remove it
+  package { 'lr-python3' : ensure => absent }
+
+}

--- a/manifests/dependencies/python.pp
+++ b/manifests/dependencies/python.pp
@@ -29,4 +29,8 @@ class wsgi::dependencies::python () {
   # As lr-python3 could exist on systems as we used it previously, we'll remove it
   package { 'lr-python3' : ensure => absent }
 
+  # As the IUS packages conflict with the EPEL ones, ensure EPEL packages are not installed.
+  $epel_packages = ["python${ver}", "python${ver}-pip", "python${ver}-setuptools"]
+  package { $epel_packages : ensure => absent }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,12 +10,7 @@
 class wsgi () inherits wsgi::params {
 
   include wsgi::dependencies::java
-
-  package { $::wsgi::params::python_pkg:
-    ensure   => present,
-    provider => rpm,
-    source   => $::wsgi::params::python_pkg_url
-  }
+  include wsgi::dependencies::python
 
   file { ['/opt/landregistry','/opt/landregistry/applications']:
     ensure => directory,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,9 +9,7 @@
 #
 class wsgi () inherits wsgi::params {
 
-  package { ['java-1.8.0-openjdk', 'java-1.8.0-openjdk-devel'] :
-    ensure => present,
-  }
+  include wsgi::dependencies::java
 
   package { $::wsgi::params::python_pkg:
     ensure   => present,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,9 +18,6 @@ class wsgi::params {
   case $::osfamily {
     'RedHat': {
 
-      $python_pkg     = 'lr-python3-3.4.3-1.x86_64'
-      $python_pkg_url = 'http://rpm.landregistryconcept.co.uk/landregistry/x86_64/lr-python3-3.4.3-1.x86_64.rpm'
-
       $systemd   = '/usr/lib/systemd/system'
       $logrotate = '/etc/logrotate.d'
 

--- a/manifests/types/python.pp
+++ b/manifests/types/python.pp
@@ -27,7 +27,7 @@ define wsgi::types::python(
     }
 
     exec { "${name} virtualenv":
-      command => "pyvenv3 ${venv_dir}",
+      command => "python3 -m venv ${venv_dir}",
       user    => $owner,
       group   => $group,
       creates => "${venv_dir}/bin/activate",

--- a/manifests/types/wsgi.pp
+++ b/manifests/types/wsgi.pp
@@ -26,7 +26,7 @@ define wsgi::types::wsgi(
     }
 
     exec { "${name} virtualenv":
-      command => "pyvenv3 ${venv_dir}",
+      command => "python3 -m venv ${venv_dir}",
       user    => $owner,
       group   => $group,
       creates => "${venv_dir}/bin/activate",


### PR DESCRIPTION
I've made some changes to switch the Python3 version used and managed by the `wsgi` module over to use the one provided by [IUS](https://ius.io) rather than the custom one provided by `lr-python3`. I would have liked to use the one provided by EPEL but unfortunately the maintainers still seem to have broken pyvenv.

I've split the Java and Python installations into separate classes required by the `wsgi` class.
I've also done some work to enable these to easily be updated later to support further version changes.

This could easily be built upon to switch the new `wsgi::dependencies::python` class over to a custom resource type and permit multiple side-by-side Python3 installs which will future proof the use of this module.