### PR TITLE
Fix premissions setting execution order issue

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -329,7 +329,7 @@ define wsgi::application (
     exec { "file-ownership-${name}" :
       command => "/usr/bin/chown -R ${app_user}:${app_group} ${directory}",
       onlyif  => "/usr/bin/test $(/usr/bin/find ${directory} ! -user ${app_user} | wc -l) != '0'",
-      require => File[$directory]
+      require => Vcsrepo[$code_dir]
     }
 
     exec { "systemd-reload-${name}" :


### PR DESCRIPTION
It appears that due to an incorrect resource relationship it was possible for permissions on the source directory to be set before the clone of the source code itself. This change should now ensure that the correct file permissions are set after the source has been cloned. 