### PR TITLE
Change logrotate config file owner to root

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -255,8 +255,8 @@ define wsgi::application (
 
       file { $logrotate_file :
         ensure  => present,
-        owner   => $app_user,
-        group   => $app_group,
+        owner   => root,
+        group   => root,
         mode    => '0644',
         content => template('wsgi/logrotate.erb')
       }

--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -255,8 +255,8 @@ define wsgi::application (
 
       file { $logrotate_file :
         ensure  => present,
-        owner   => root,
-        group   => root,
+        owner   => 'root',
+        group   => 'root',
         mode    => '0644',
         content => template('wsgi/logrotate.erb')
       }


### PR DESCRIPTION
Logrotate won't read a config file not owned by root
This an intended behaviour for logrotate