### PR TITLE
Amend permissions as per pen test recomendation

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -270,7 +270,7 @@ define wsgi::application (
       ensure  => file,
       owner   => $app_user,
       group   => $app_group,
-      mode    => '0664',
+      mode    => '0640',
       content => template('wsgi/environment.erb'),
       require => File[$directory],
       notify  => $service_notify
@@ -280,7 +280,7 @@ define wsgi::application (
       ensure  => file,
       owner   => $app_user,
       group   => $app_group,
-      mode    => '0664',
+      mode    => '0640',
       content => template('wsgi/deploy.erb'),
       require => File[$directory],
       notify  => $service_notify


### PR DESCRIPTION
Following a recommendation on a recent pen test report the file permissions on the settings.conf and deploy.conf files have been amended so that they are no loner world readable.  