### PR TITLE
Jrs logrotate

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -124,11 +124,20 @@ define wsgi::application (
       require => Class[wsgi]
     }
 
-    file { [$venv_dir, $logs_dir, $code_dir]:
+    file { [$venv_dir, $code_dir]:
       ensure  => directory,
       owner   => $app_user,
       group   => $app_group,
       mode    => '0775',
+      require => File[$directory]
+    }
+
+    file { $logs_dir:
+      ensure  => directory,
+      owner   => $app_user,
+      group   => $app_group,
+      mode    => '0775',
+      seltype => 'var_log_t',
       require => File[$directory]
     }
 
@@ -137,6 +146,7 @@ define wsgi::application (
       owner   => $app_user,
       group   => $app_group,
       mode    => '0644',
+      seltype => 'var_log_t',
       require => File[$directory]
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "landregistry-wsgi",
-  "version": "1.2.2",
+  "version": "1.3.2",
   "author": "landregistry",
   "summary": "Deploy Land Registry applications",
   "license": "MIT",


### PR DESCRIPTION
added seltype to file pragma in application.pp in manifest so that logrotate can rotate logs without selinux stopping it. Up'd the version in metadata.json