### PR TITLE
Add healthcheck param to be used for nagios

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -33,7 +33,7 @@ define wsgi::application (
   $extra_args   = undef,
   $no_service   = false,
   $log_fields   = [],
-  $healthcheck  = false
+  $healthcheck  = false,
   $repo_type    = 'git',
   $rpm_repo     = "${name}-repo",
   $rpm_package  = undef,

--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -33,6 +33,7 @@ define wsgi::application (
   $extra_args   = undef,
   $no_service   = false,
   $log_fields   = [],
+  $healthcheck  = false
 ) {
 
   include stdlib


### PR DESCRIPTION
Add health check parameter - Not currently used within the module itself but added so that it can be included in the application hash which is also interrogated by the application profile to configure nagios health checks. 