### PR TITLE
Add check for python_no_service app type

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -275,7 +275,7 @@ define wsgi::application (
         bind     => $bind
       }
 
-    } elsif ($app_type == 'python') {
+    } elsif ($app_type in ['python', 'python_no_service']) {
 
       wsgi::types::python { $name:
         code_dir  => $code_dir,

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -65,6 +65,16 @@ wsgi::application { 'test-python-app' :
     'TESTVALUE' => 'test',
   }
 } ->
+wsgi::application { 'test-python-no-service-app':
+  bind        => '5005',
+  source      => 'https://github.com/mooreandrew/test-app.git',
+  environment => 'Integration',
+  app_type    => 'python_no_service',
+  no_service  => true,
+  vars        => {
+    'TESTVALUE' => 'test'
+  }
+} ->
 wsgi::application { 'scheduled_file' :
   source      => 'https://github.com/mooreandrew/gradle-test-jar.git',
   environment => 'Integration',


### PR DESCRIPTION
Add a condition for the app type `python_no_service` to allow python scripts to be set up with virtualenvs without setting up nagios service checks